### PR TITLE
chore(ci): add dependabot for github-actions and uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Garde les actions GitHub (épinglées par SHA) à jour — l'écosystème
+  # pertinent pour ce dépôt de contenu.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    # Laisser décanter une nouvelle release : un paquet compromis est
+    # généralement retiré en quelques jours, un cooldown réduit la fenêtre.
+    cooldown:
+      default-days: 7
+
+  # Dépendances Python de dev (pytest, dsoxlab) via uv.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Enables the Dependency-Update-Tool (weekly PRs to bump the SHA-pinned GitHub Actions and the dev Python deps), with a 7-day cooldown to shrink the exposure window on freshly published versions.