### PR TITLE
chore(ci): Plumber solo (code owner non requis)

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -826,7 +826,7 @@ github:
         - production
         - dev
       allowForcePush: false
-      codeOwnerApprovalRequired: true
+      codeOwnerApprovalRequired: false
 
     # ============================================================================
     # Workflows must include required actions


### PR DESCRIPTION
Relâche codeOwnerApprovalRequired pour un mainteneur unique → Plumber 100.