### PR TITLE
fix(ci): retirer les paliers semver du cooldown dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,13 @@ updates:
       prefix: "chore(ci)"
     # Laisser décanter une nouvelle release : un paquet compromis est
     # généralement retiré en quelques jours, un cooldown réduit la fenêtre.
-    # Quarantaine graduée : plus le saut de version est large, plus le risque
-    # d'une release compromise ou régressive est élevé, plus on attend.
+    #
+    # `default-days` seul : les paliers semver-{major,minor,patch}-days ne sont
+    # PAS supportés pour l'écosystème github-actions (ils valent pour les
+    # écosystèmes de paquets type pip/npm). Les déclarer ici fait échouer la
+    # validation du fichier côté GitHub.
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
 
   # Pas d'écosystème "uv" ici : ce dépôt de contenu n'a aucune dépendance
   # Python à builder (pyproject.toml : package = false, dependencies = []).


### PR DESCRIPTION
Les propriétés `semver-{major,minor,patch}-days` ne sont pas supportées pour l'écosystème `github-actions` : GitHub refuse le fichier à la validation.

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
```

Ces paliers valent pour les écosystèmes de paquets (pip, npm...), pas pour les actions. Retour à `default-days: 7` seul — la quarantaine de 7 jours voulue est conservée — avec la raison en commentaire pour ne pas refaire l'erreur.

Régression introduite par #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)