### PR TITLE
fix(labs): catalogue découpé par section, et drills qui prouvent l'interdit

### DIFF
--- a/labs/linux/capstones/lfcs-mock-exam/lab.yaml
+++ b/labs/linux/capstones/lfcs-mock-exam/lab.yaml
@@ -1,7 +1,7 @@
 id: lfcs-mock-exam
 title: "LFCS mock exam — 17 tasks on Ubuntu 24.04"
 description: "Performance-based LFCS mock exam covering the 5 official domains: Essential Commands (20%), Operations Deployment (25%), Users and Groups (10%), Networking (25%), Storage (20%). 17 tasks scored on 100 points on a single Ubuntu VM. 70/100 to pass. No hints."
-section: linux
+section: capstones
 lab_type: capstone
 level: l2
 track:

--- a/labs/linux/capstones/rhcsa-mock-exam/lab.yaml
+++ b/labs/linux/capstones/rhcsa-mock-exam/lab.yaml
@@ -1,7 +1,7 @@
 id: rhcsa-mock-exam
 title: "RHCSA EX200 mock exam — 20 tasks across 2 VMs"
 description: "Performance-based RHCSA mock exam covering 10 RHCSA domains: storage (LVM, swap, NFS), networking (static IP, firewalld), users/groups, ACLs, services (systemd units, timers, chrony), SELinux (modes, contexts, booleans, port labels), software (DNF, Flatpak), boot recovery (rd.break root reset). 20 tasks scored on 100 points across 2 VMs (server + client). 70/100 to pass. No hints."
-section: linux
+section: capstones
 lab_type: capstone
 level: l2
 track:

--- a/labs/linux/drills/drill-apparmor/lab.yaml
+++ b/labs/linux/drills/drill-apparmor/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-apparmor
 title: "Drill — AppArmor under exam conditions"
 description: "4 tasks, 100 points, 15 minutes, no hints: confirm AppArmor is up, put one profile in complain, and bring two others back to enforce. LFCS only — RHEL uses SELinux, see drill-selinux."
-section: linux
+section: drills
 lab_type: challenge
 level: l4
 track:

--- a/labs/linux/drills/drill-essential-commands/lab.yaml
+++ b/labs/linux/drills/drill-essential-commands/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-essential-commands
 title: "Drill — essential commands under exam conditions"
 description: "5 tasks, 100 points, 20 minutes, no hints: find by size, build a frequency report, links, ownership and permissions, and split stdout from stderr. Playable on RHEL or Debian — the skills are identical."
-section: linux
+section: drills
 lab_type: challenge
 level: l1
 track:

--- a/labs/linux/drills/drill-firewall/challenge/tests/test_functional.py
+++ b/labs/linux/drills/drill-firewall/challenge/tests/test_functional.py
@@ -123,9 +123,26 @@ def test_task5_telnet_rejected(host):
         )
     else:
         regles = host.check_output("firewall-cmd --list-all")
-        assert "port=\"23\"" in regles or "port=23" in regles, (
+        ligne = next(
+            (
+                entree
+                for entree in regles.splitlines()
+                if 'port="23"' in entree or "port=23" in entree
+            ),
+            "",
+        )
+        assert ligne, (
             "Aucune règle riche ne vise le port 23. Une règle riche de rejet "
             f"est attendue. Vu :\n{regles}"
+        )
+        # Viser le port ne suffit pas : il faut le REJETER. Sans ce contrôle,
+        # une règle riche « accept » sur le port 23 marquait les 20 points de
+        # la tâche « Telnet, jamais », en ouvrant précisément ce qu'elle
+        # demande de fermer.
+        assert "reject" in ligne.lower() or "drop" in ligne.lower(), (
+            "La règle riche vise bien 23/tcp mais ne le rejette pas. "
+            "L'énoncé demande un rejet explicite, pas une simple mention du "
+            f"port. Vu : {ligne!r}"
         )
         assert "reject" in regles or "drop" in regles, (
             f"Le port 23 doit être rejeté, pas autorisé. Vu :\n{regles}"

--- a/labs/linux/drills/drill-firewall/lab.yaml
+++ b/labs/linux/drills/drill-firewall/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-firewall
 title: "Drill — firewall under exam conditions"
 description: "5 tasks, 100 points, 20 minutes, no hints: bring the firewall up, open two ports so they survive a reload, keep SSH alive, and explicitly reject a port. The objective is shared by RHCSA and LFCS — only the tool changes (firewalld or ufw)."
-section: linux
+section: drills
 lab_type: challenge
 level: l4
 track:

--- a/labs/linux/drills/drill-network/lab.yaml
+++ b/labs/linux/drills/drill-network/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-network
 title: "Drill — static networking under exam conditions"
 description: "4 tasks, 100 points, 20 minutes, no hints: a static address, a static route and an MTU on a dedicated interface, plus local name resolution. The objective is shared by RHCSA and LFCS — only the tool changes (nmcli or netplan)."
-section: linux
+section: drills
 lab_type: challenge
 level: l4
 track:

--- a/labs/linux/drills/drill-packages/lab.yaml
+++ b/labs/linux/drills/drill-packages/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-packages
 title: "Drill — package management under exam conditions"
 description: "5 tasks, 100 points, 20 minutes, no hints: install a package, freeze it against upgrades, find which package owns a file, list what a package installed, and remove one. The objective is shared by RHCSA and LFCS — only the tool changes (dnf or apt), and you use your distribution's."
-section: linux
+section: drills
 lab_type: challenge
 level: l2
 track:

--- a/labs/linux/drills/drill-selinux/lab.yaml
+++ b/labs/linux/drills/drill-selinux/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-selinux
 title: "Drill — SELinux under exam conditions"
 description: "4 tasks, 100 points, 20 minutes, no hints: put SELinux back in enforcing for good, fix a file context so it survives a relabel, flip a boolean persistently, and label a non-standard port. RHCSA only — Debian uses AppArmor, see drill-apparmor."
-section: linux
+section: drills
 lab_type: challenge
 level: l4
 track:

--- a/labs/linux/drills/drill-storage/lab.yaml
+++ b/labs/linux/drills/drill-storage/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-storage
 title: "Drill — partitions, LVM and swap under exam conditions"
 description: "5 tasks, 100 points, 25 minutes, no hints: partition a disk in GPT, build an LVM stack, mount by UUID persistently, add swap, and extend a logical volume online. Playable on RHEL or Debian — parted, LVM and XFS are identical."
-section: linux
+section: drills
 lab_type: challenge
 level: l2
 track:

--- a/labs/linux/drills/drill-systemd/lab.yaml
+++ b/labs/linux/drills/drill-systemd/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-systemd
 title: "Drill — systemd units, timers and scheduling under exam conditions"
 description: "5 tasks, 100 points, 25 minutes, no hints: write a service unit with a restart policy, schedule a weekly timer, add a cron job, fix the default boot target, and mask a service for good. Playable on RHEL or Debian — systemd is systemd."
-section: linux
+section: drills
 lab_type: challenge
 level: l3
 track:

--- a/labs/linux/drills/drill-users-groups/challenge/tests/test_functional.py
+++ b/labs/linux/drills/drill-users-groups/challenge/tests/test_functional.py
@@ -95,6 +95,27 @@ def test_task4_sudo_delegation_actually_works(host):
         f"Le script doit s'exécuter en root (uid=0). Vu : {res.stdout!r}"
     )
 
+    # « Et rien de plus » : le versant interdit de la tâche. Sans cette
+    # assertion, « %ops ALL=(ALL) NOPASSWD: ALL » marquait les 20 points,
+    # alors que c'est le root complet, soit l'exact contraire du moindre
+    # privilège demandé. Un drill de sécurité doit prouver ce qui est
+    # interdit, pas seulement ce qui est permis.
+    #
+    # Assertion gardée DANS ce test plutôt que dans un test séparé : le score
+    # se calcule par test, et les cinq tâches valent 20 points chacune. Un
+    # sixième test ramènerait chaque tâche à 16,7 points.
+    #
+    # /usr/bin/id sert de témoin : aucune raison de le déléguer, et son refus
+    # est net (sudo sort en erreur avec « not allowed to execute »).
+    trop_large = host.run("runuser -u deploy -- sudo -n /usr/bin/id")
+    assert trop_large.rc != 0, (
+        "deploy peut lancer /usr/bin/id en root, alors que la tâche ne "
+        "délègue que /usr/local/bin/ops-report.sh. La règle sudo est trop "
+        "large (un NOPASSWD: ALL, ou un chemin en ALL) : elle accorde le root "
+        "complet. Restreins-la à la seule commande demandée.\n"
+        f"Sortie : {trop_large.stdout}{trop_large.stderr}"
+    )
+
 
 @pytest.mark.points(20)
 def test_task5_departing_account_locked(host):
@@ -106,8 +127,11 @@ def test_task5_departing_account_locked(host):
         f"afficher L en 2e champ). Vu : {statut!r}"
     )
     shell = host.user("former").shell
-    assert shell.endswith("nologin"), (
-        "Le shell de former doit interdire la connexion (…/nologin) : "
-        "verrouiller le mot de passe ne suffit pas, une clé SSH passerait "
-        f"encore. Vu : {shell}."
+    # L'énoncé demande un shell qui « interdit la connexion », pas nommément
+    # nologin : /bin/false et /sbin/nologin remplissent tous deux le contrat.
+    # N'accepter que nologin recalait une réponse juste.
+    assert shell.endswith(("nologin", "false")), (
+        "Le shell de former doit interdire la connexion (…/nologin ou "
+        "/bin/false) : verrouiller le mot de passe ne suffit pas, une clé SSH "
+        f"passerait encore. Vu : {shell}."
     )

--- a/labs/linux/drills/drill-users-groups/lab.yaml
+++ b/labs/linux/drills/drill-users-groups/lab.yaml
@@ -1,7 +1,7 @@
 id: drill-users-groups
 title: "Drill — users, groups and delegation under exam conditions"
 description: "5 tasks, 100 points, 20 minutes, no hints: create an account to exact specs, enforce password aging, build a collaborative directory, delegate sudo narrowly, and lock a departing account. Playable on RHEL or Debian — user management is identical."
-section: linux
+section: drills
 lab_type: challenge
 level: l2
 track:

--- a/labs/linux/l1/l1-bash-script/lab.yaml
+++ b/labs/linux/l1/l1-bash-script/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-bash-script
 title: "Write a first Bash script: variables, a loop and a condition"
 description: "Write rapport.sh that reads a status file passed as an argument, counts UP/DOWN with a loop, prints them, and exits non-zero when any host is down."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-choose-distro/lab.yaml
+++ b/labs/linux/l1/l1-choose-distro/lab.yaml
@@ -2,7 +2,7 @@ id: l1-choose-distro
 title: Choose your reference Linux distribution
 description: Compare Debian/Ubuntu and RHEL-based distributions, understand the criteria
   for choosing between them, and document your choice for three practical scenarios.
-section: linux
+section: l1
 level: l1
 lab_type: lab
 bloc: 0

--- a/labs/linux/l1/l1-discover-linux-map/lab.yaml
+++ b/labs/linux/l1/l1-discover-linux-map/lab.yaml
@@ -3,7 +3,7 @@ title: 'Map Linux: kernel, distribution and key directories'
 description: 'Explore what Linux is made of: run real commands on your own system
   to discover the kernel, your distribution and the role of /etc, /var/log and /proc.
   Fill in a knowledge map.'
-section: linux
+section: l1
 level: l1
 lab_type: lab
 bloc: 0

--- a/labs/linux/l1/l1-env-profiles/lab.yaml
+++ b/labs/linux/l1/l1-env-profiles/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-env-profiles
 title: "Environment variables: export, PATH and a sourced env file"
 description: "Write env.sh that, when sourced, exports variables, reuses one in another, and prepends a bin directory to PATH — proven by sourcing it in a subshell."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-find-files/lab.yaml
+++ b/labs/linux/l1/l1-find-files/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-find-files
 title: "Locate files with find by name, size and permissions"
 description: "Extract a project tree and use find to list files by name pattern, by size and by exact permissions — producing the results into files that are checked against the real tree."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-first-terminal/lab.yaml
+++ b/labs/linux/l1/l1-first-terminal/lab.yaml
@@ -2,7 +2,7 @@ id: l1-first-terminal
 title: First steps in the terminal
 description: Run basic commands (whoami, pwd, hostname, date) and capture the output
   in a file.
-section: linux
+section: l1
 lab_type: lab
 level: l1
 bloc: 0

--- a/labs/linux/l1/l1-get-help/lab.yaml
+++ b/labs/linux/l1/l1-get-help/lab.yaml
@@ -2,7 +2,7 @@ id: l1-get-help
 title: Get help from the command line
 description: Use man, --help, and apropos to find the right command options without
   searching the web.
-section: linux
+section: l1
 lab_type: lab
 level: l1
 bloc: 0

--- a/labs/linux/l1/l1-git-basics/lab.yaml
+++ b/labs/linux/l1/l1-git-basics/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-git-basics
 title: "Initialize a Git repo: commit, history and a branch"
 description: "Create a repository, make two commits tracking real files, and open a feature branch — proven by inspecting the repository state itself."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-grep-regex/lab.yaml
+++ b/labs/linux/l1/l1-grep-regex/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-grep-regex
 title: "Filter a log with grep and regular expressions"
 description: "Use grep with anchors, character classes, invert-match and count to extract exact facts from an access log."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-links-hard-sym/lab.yaml
+++ b/labs/linux/l1/l1-links-hard-sym/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-links-hard-sym
 title: "Create hard and symbolic links and tell them apart"
 description: "Make a hard link that shares the inode, a symbolic link that points by path, and a symlink to a directory — proven by inode, link count and link target."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-linux-filesystem/lab.yaml
+++ b/labs/linux/l1/l1-linux-filesystem/lab.yaml
@@ -2,7 +2,7 @@ id: l1-linux-filesystem
 title: Linux filesystem hierarchy (FHS)
 description: Match the standard Linux directories to their roles and classify files
   by location.
-section: linux
+section: l1
 lab_type: lab
 level: l1
 bloc: 1

--- a/labs/linux/l1/l1-navigate-filesystem/lab.yaml
+++ b/labs/linux/l1/l1-navigate-filesystem/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-navigate-filesystem
 title: Navigate the filesystem
 description: Use cd, ls, mkdir, cp, mv, rm to build a target directory tree from scratch.
-section: linux
+section: l1
 lab_type: lab
 level: l1
 bloc: 1

--- a/labs/linux/l1/l1-paths-absolute-relative/lab.yaml
+++ b/labs/linux/l1/l1-paths-absolute-relative/lab.yaml
@@ -2,7 +2,7 @@ id: l1-paths-absolute-relative
 title: Absolute and relative paths
 description: Copy a file using an absolute path and a relative path, then solve 5
   path navigation puzzles.
-section: linux
+section: l1
 lab_type: lab
 level: l1
 bloc: 1

--- a/labs/linux/l1/l1-permissions-ugo/lab.yaml
+++ b/labs/linux/l1/l1-permissions-ugo/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-permissions-ugo
 title: "Set exact file permissions with chmod (octal and symbolic)"
 description: "Give each file the right owner/group/other bits: a private secret, an executable script, a group-readable note and a private directory."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-prepare-vm/lab.yaml
+++ b/labs/linux/l1/l1-prepare-vm/lab.yaml
@@ -2,7 +2,7 @@ id: l1-prepare-vm
 title: Identify your Linux machine
 description: Run commands to collect your system's hostname, distribution, kernel
   version and IP address. Produce a machine identity card stored in vm-info.txt.
-section: linux
+section: l1
 level: l1
 lab_type: lab
 bloc: 0

--- a/labs/linux/l1/l1-read-a-command/lab.yaml
+++ b/labs/linux/l1/l1-read-a-command/lab.yaml
@@ -2,7 +2,7 @@ id: l1-read-a-command
 title: Read and decode a command
 description: Decompose 5 Linux commands into their command/options/arguments parts
   and fix 3 broken commands.
-section: linux
+section: l1
 lab_type: lab
 level: l1
 bloc: 0

--- a/labs/linux/l1/l1-redirections-pipes/lab.yaml
+++ b/labs/linux/l1/l1-redirections-pipes/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-redirections-pipes
 title: "Redirect streams and chain commands with pipes"
 description: "Redirect stdout and stderr, merge them, and chain commands with pipes to produce exact artifacts."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-ssl-certificates/lab.yaml
+++ b/labs/linux/l1/l1-ssl-certificates/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-ssl-certificates
 title: "Inspect a TLS certificate with openssl"
 description: "Read a delivered X.509 certificate: extract its subject, validity dates, SHA-256 fingerprint and public key with openssl x509."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-tar-archives/lab.yaml
+++ b/labs/linux/l1/l1-tar-archives/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-tar-archives
 title: "Archive, compress and selectively extract with tar, gzip and bzip2"
 description: "Create gzip and bzip2 tarballs, list their contents, and extract a single member into a target directory."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l1/l1-text-processing/lab.yaml
+++ b/labs/linux/l1/l1-text-processing/lab.yaml
@@ -1,7 +1,7 @@
 id: l1-text-processing
 title: "Transform and aggregate text with cut, sort, uniq, sed and awk"
 description: "Slice columns, deduplicate, count occurrences, sum a field and rewrite a delimiter to turn a raw record file into exact facts."
-section: linux
+section: l1
 lab_type: lab
 level: l1
 track:

--- a/labs/linux/l2/l2-acl-posix/lab.yaml
+++ b/labs/linux/l2/l2-acl-posix/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-acl-posix
 title: "Grant fine-grained access with POSIX ACLs"
 description: "Go beyond ugo: give one user rw on a file and a group rx on a directory, with a default ACL so new files inherit it — using setfacl/getfacl."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-autofs-ondemand/lab.yaml
+++ b/labs/linux/l2/l2-autofs-ondemand/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-autofs-ondemand
 title: "Mount a filesystem on demand with autofs"
 description: "Configure autofs so that accessing /autofs/data mounts the spare disk automatically, and unmounts it after idle — a master map plus a mount map."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-collaborative-setgid/lab.yaml
+++ b/labs/linux/l2/l2-collaborative-setgid/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-collaborative-setgid
 title: "Set up a collaborative directory with the set-GID bit"
 description: "Give a shared directory the devteam group and the set-GID bit so files created inside inherit the group — proven by the directory mode and a member's new file."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-disk-space-troubleshoot/lab.yaml
+++ b/labs/linux/l2/l2-disk-space-troubleshoot/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-disk-space-troubleshoot
 title: "Diagnose a full filesystem and reclaim space"
 description: "A filesystem is full. Find the culprit with df/du, remove the junk without deleting the legitimate data, and bring usage back down."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-filesystem-create-xfs/lab.yaml
+++ b/labs/linux/l2/l2-filesystem-create-xfs/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-filesystem-create-xfs
 title: "Create and label an XFS filesystem, then mount it"
 description: "Format a prepared partition as XFS with a label, create a mount point and mount it — proven by the filesystem type, its label and the active mount."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-fstab-persist-uuid/lab.yaml
+++ b/labs/linux/l2/l2-fstab-persist-uuid/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-fstab-persist-uuid
 title: "Mount a filesystem persistently by UUID in /etc/fstab"
 description: "Mount a pre-formatted extra disk at /srv/data through /etc/fstab, referenced by UUID (not device name) so it survives a reboot, and prove the line with mount -a AND findmnt --verify."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-luks-encryption/lab.yaml
+++ b/labs/linux/l2/l2-luks-encryption/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-luks-encryption
 title: "Encrypt a disk with LUKS"
 description: "Encrypt a block device with LUKS2, open it, put a filesystem on it, mount it and make it unlock at boot via crypttab."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-lvm-extend-persist/lab.yaml
+++ b/labs/linux/l2/l2-lvm-extend-persist/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-lvm-extend-persist
 title: "Extend a logical volume and prove the mount survives a reboot"
 description: "Extend an LVM logical volume, grow the XFS filesystem, and make the mount persistent via /etc/fstab by UUID."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-nfs-mount-persist/lab.yaml
+++ b/labs/linux/l2/l2-nfs-mount-persist/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-nfs-mount-persist
 title: "Mount an NFS export persistently from a server"
 description: "A second host exports an NFS share. Mount it on the client at /mnt/nfs, make it persistent in /etc/fstab with _netdev so it survives a reboot."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-package-management/lab.yaml
+++ b/labs/linux/l2/l2-package-management/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-package-management
 title: "Install, remove and query packages with dnf"
 description: "Bring the machine to a target software state: install a needed package, remove an unwanted one, and confirm with dnf/rpm queries."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-partition-gpt/lab.yaml
+++ b/labs/linux/l2/l2-partition-gpt/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-partition-gpt
 title: "Create GPT partitions on a disk with parted"
 description: "Put a GPT label on the spare disk and carve two partitions (512 MiB and 1 GiB), then make the kernel re-read the table."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-password-policy/lab.yaml
+++ b/labs/linux/l2/l2-password-policy/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-password-policy
 title: "Enforce password aging and complexity policy"
 description: "Set per-account password aging with chage, the system default max age in login.defs, and a minimum password length via pwquality."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-raid-mdadm/lab.yaml
+++ b/labs/linux/l2/l2-raid-mdadm/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-raid-mdadm
 title: "Build a software RAID 1 with mdadm"
 description: "Assemble two disks into a redundant RAID 1 array with mdadm, format and mount it, and make it persistent."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-repo-configure/lab.yaml
+++ b/labs/linux/l2/l2-repo-configure/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-repo-configure
 title: "Configure a dnf repository with a .repo file"
 description: "Add a software repository under /etc/yum.repos.d: an id, a baseurl, enabled and GPG-checked, then confirm dnf sees it."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-storage-performance/lab.yaml
+++ b/labs/linux/l2/l2-storage-performance/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-storage-performance
 title: "Tune a mount for performance with noatime (persistently)"
 description: "A read-heavy filesystem wastes I/O writing access times. Add the noatime mount option, make it active and persistent in /etc/fstab."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-sudo-delegation/lab.yaml
+++ b/labs/linux/l2/l2-sudo-delegation/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-sudo-delegation
 title: "Delegate limited sudo rights with a sudoers drop-in"
 description: "Grant the operators group password-less sudo for systemctl only, via a validated /etc/sudoers.d drop-in — least privilege, not full root."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-swap-management/lab.yaml
+++ b/labs/linux/l2/l2-swap-management/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-swap-management
 title: "Add and manage swap space"
 description: "Create a secure swap file, activate it, make it persistent in /etc/fstab and tune vm.swappiness."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l2/l2-user-lifecycle/lab.yaml
+++ b/labs/linux/l2/l2-user-lifecycle/lab.yaml
@@ -1,7 +1,7 @@
 id: l2-user-lifecycle
 title: "Create a local account with exact UID, shell and groups"
 description: "Onboard a user with a specific UID, home, login shell, a primary group and a supplementary group — the RHCSA account-creation drill."
-section: linux
+section: l2
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/l3/l3-app-constraints/lab.yaml
+++ b/labs/linux/l3/l3-app-constraints/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-app-constraints
 title: "Set per-user resource limits (open files) with limits.d"
 description: "Give the appuser account a higher open-files limit via /etc/security/limits.d — proven by the effective ulimit in a real login session."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-boot-target/lab.yaml
+++ b/labs/linux/l3/l3-boot-target/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-boot-target
 title: "Set the default systemd boot target"
 description: "A server has no business booting into a graphical target. Set the default to multi-user.target and confirm it."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-fs-readonly-recover/lab.yaml
+++ b/labs/linux/l3/l3-fs-readonly-recover/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-fs-readonly-recover
 title: "Recover a read-only mount caused by a broken fstab"
 description: "A bad /etc/fstab option left /srv/data mounted read-only. Fix the entry, remount read-write, and make mount -a clean again."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-grub-kernel-args/lab.yaml
+++ b/labs/linux/l3/l3-grub-kernel-args/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-grub-kernel-args
 title: "Add a persistent kernel boot parameter"
 description: "Add a kernel command-line parameter to the current kernel with grubby and to /etc/default/grub for future kernels, so it survives reboots and updates — proven by grubby and the grub config."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-journald-persist/lab.yaml
+++ b/labs/linux/l3/l3-journald-persist/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-journald-persist
 title: "Make the systemd journal persistent across reboots"
 description: "By default logs vanish on reboot. Enable persistent journald storage so /var/log/journal keeps history — proven by config, directory and a real journal file."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-process-signals-priority/lab.yaml
+++ b/labs/linux/l3/l3-process-signals-priority/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-process-signals-priority
 title: "Lower a service's scheduling priority with Nice"
 description: "A batch worker hogs the CPU. Give its service a nice value of 10 so it yields to interactive work — proven by the live process priority and the unit config."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-scheduling-at/lab.yaml
+++ b/labs/linux/l3/l3-scheduling-at/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-scheduling-at
 title: "Schedule a one-shot job with at"
 description: "Queue a command to run once at a later time with at, and prove it is scheduled — the one-off counterpart to cron."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-scheduling-cron/lab.yaml
+++ b/labs/linux/l3/l3-scheduling-cron/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-scheduling-cron
 title: "Schedule a recurring job with cron"
 description: "Run /usr/local/bin/report.sh every day at 02:30 through a cron entry — proven by the actual schedule the cron daemon will honour."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-scheduling-timers/lab.yaml
+++ b/labs/linux/l3/l3-scheduling-timers/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-scheduling-timers
 title: "Schedule a recurring job with a systemd timer"
 description: "Create a .service and its .timer (OnCalendar), enable it, and prove it is active and persistent — the systemd way to schedule recurring work."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-service-create-unit/lab.yaml
+++ b/labs/linux/l3/l3-service-create-unit/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-service-create-unit
 title: "Create and enable a systemd service unit"
 description: "Wrap a program in a systemd .service unit, start it and enable it at boot — proven by the service being active, enabled and doing its job."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-service-diagnose/lab.yaml
+++ b/labs/linux/l3/l3-service-diagnose/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-service-diagnose
 title: "Diagnose and fix a systemd service stuck in a crash loop"
 description: "A systemd service keeps restarting because of a missing config file. Use systemctl + journalctl to find the root cause and fix it permanently."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-ssh-access-recovery/lab.yaml
+++ b/labs/linux/l3/l3-ssh-access-recovery/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-ssh-access-recovery
 title: "Repair a broken sshd config before it locks you out"
 description: "A drop-in left an invalid directive: sshd -t fails, so the next reload or reboot would kill remote access. Fix the config, keep root login disabled, and reload cleanly."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-sysctl-persist/lab.yaml
+++ b/labs/linux/l3/l3-sysctl-persist/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-sysctl-persist
 title: "Harden kernel parameters persistently with sysctl.d"
 description: "Disable IP forwarding and ICMP redirects via /etc/sysctl.d, applied now and surviving reboot — proven by the live sysctl values."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l3/l3-tuned-profile/lab.yaml
+++ b/labs/linux/l3/l3-tuned-profile/lab.yaml
@@ -1,7 +1,7 @@
 id: l3-tuned-profile
 title: "Apply a tuned performance profile"
 description: "Switch the active tuned profile to throughput-performance and make it stick — proven by the active profile the tuned daemon reports."
-section: linux
+section: l3
 lab_type: lab
 level: l3
 track:

--- a/labs/linux/l4/l4-bridge-bonding/lab.yaml
+++ b/labs/linux/l4/l4-bridge-bonding/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-bridge-bonding
 title: "Aggregate links: an active-backup bond under a bridge with nmcli"
 description: "Build an active-backup bond over two slave interfaces and put a bridge on top, persistently with NetworkManager — proven by the bonding state and the bridge port."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-firewall-persist/lab.yaml
+++ b/labs/linux/l4/l4-firewall-persist/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-firewall-persist
 title: "Open a firewalld service permanently"
 description: "Allow the http service through firewalld so it holds now and after reload/reboot — proven by the runtime and permanent service lists, without ever closing ssh."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-ldap-integration/lab.yaml
+++ b/labs/linux/l4/l4-ldap-integration/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-ldap-integration
 title: "Authenticate Linux against an LDAP directory with SSSD"
 description: "Configure SSSD on the client so a directory user (alice) resolves and can log in, against a 389 Directory Server — proven by getent, id and the active authselect profile."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-nat-portforward/lab.yaml
+++ b/labs/linux/l4/l4-nat-portforward/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-nat-portforward
 title: "Set up persistent NAT port forwarding with nftables"
 description: "Enable IP forwarding and add an nftables nat table (DNAT port forward + masquerade) that survives reboot — proven by the live ruleset, sysctl and persistence files."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-network-static-persist/lab.yaml
+++ b/labs/linux/l4/l4-network-static-persist/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-network-static-persist
 title: "Configure a persistent static IPv4 with NetworkManager"
 description: "Create a NetworkManager connection with a static IPv4 (manual method) that survives reboot — proven by the on-disk profile and the live address."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-network-troubleshoot/lab.yaml
+++ b/labs/linux/l4/l4-network-troubleshoot/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-network-troubleshoot
 title: "Diagnose and restore a down network connection"
 description: "A NetworkManager connection is configured but stays down and won't auto-start. Diagnose it, bring it up, and make it auto-connect — proven by the live state and autoconnect flag."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-ntp-sync/lab.yaml
+++ b/labs/linux/l4/l4-ntp-sync/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-ntp-sync
 title: "Synchronize the clock with chrony and set the timezone, persistently"
 description: "Enable and start chronyd, turn NTP on and set the timezone to Europe/Paris — surviving reboot, proven by the live service state and timedatectl."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-podman-basic/lab.yaml
+++ b/labs/linux/l4/l4-podman-basic/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-podman-basic
 title: "Run a detached container with Podman"
 description: "Pull an image and run a named container detached, and prove it is up — the Podman basics for RHCSA containers."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-podman-images/lab.yaml
+++ b/labs/linux/l4/l4-podman-images/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-podman-images
 title: "Manage container images: pull, tag, save and inspect"
 description: "Pull an image from a registry, tag it, save it to an archive and inspect that archive with skopeo — the image-management skills for RHCSA containers."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-podman-systemd-persist/lab.yaml
+++ b/labs/linux/l4/l4-podman-systemd-persist/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-podman-systemd-persist
 title: "Run a container as a systemd service with Quadlet (boot-persistent)"
 description: "Define a Quadlet .container unit so a container starts at boot under systemd — proven by the active service, the running container and the on-disk unit."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-reverse-proxy-lb/lab.yaml
+++ b/labs/linux/l4/l4-reverse-proxy-lb/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-reverse-proxy-lb
 title: "Load-balance a web backend with HAProxy"
 description: "Configure HAProxy on the front host to reverse-proxy and load-balance to a backend web server, persistently — proven by a request through the proxy returning the backend's page."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-selinux-boolean-port/lab.yaml
+++ b/labs/linux/l4/l4-selinux-boolean-port/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-selinux-boolean-port
 title: "Allow a service with SELinux: persistent boolean and labeled port"
 description: "Turn on an SELinux boolean persistently and label a non-standard port so a service is allowed under enforcing SELinux — proven by getsebool and semanage port."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-selinux-context-fix/lab.yaml
+++ b/labs/linux/l4/l4-selinux-context-fix/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-selinux-context-fix
 title: "Fix a file's SELinux context, persistently"
 description: "Give a custom web directory the httpd_sys_content_t type with semanage fcontext + restorecon so it survives a relabel/reboot — proven by ls -Z and the fcontext rule."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-selinux-diagnose-avc/lab.yaml
+++ b/labs/linux/l4/l4-selinux-diagnose-avc/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-selinux-diagnose-avc
 title: "Diagnose an SELinux denial (AVC) and fix it the right way"
 description: "A web file has the wrong SELinux label so httpd is denied (403). Read the AVC in the audit log and restore the context — without disabling SELinux. Proven by the live context and a 200 response."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/l4/l4-ssh-key-auth-harden/lab.yaml
+++ b/labs/linux/l4/l4-ssh-key-auth-harden/lab.yaml
@@ -1,7 +1,7 @@
 id: l4-ssh-key-auth-harden
 title: "Set up hardened key-based SSH access for a service user"
 description: "Give the deploy user key-based SSH login with correct ownership and permissions (.ssh 700, authorized_keys 600, owned by the user) — the classic trap that silently breaks key auth."
-section: linux
+section: l4
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/lfcs/lfcs-apparmor/lab.yaml
+++ b/labs/linux/lfcs/lfcs-apparmor/lab.yaml
@@ -1,7 +1,7 @@
 id: lfcs-apparmor
 title: "Manage an AppArmor profile: switch it to complain mode"
 description: "Put a loaded AppArmor profile into complain (learning) mode with aa-complain and prove it with aa-status — the Debian mandatory-access-control counterpart to SELinux."
-section: linux
+section: lfcs
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/lfcs/lfcs-firewall-ufw/lab.yaml
+++ b/labs/linux/lfcs/lfcs-firewall-ufw/lab.yaml
@@ -1,7 +1,7 @@
 id: lfcs-firewall-ufw
 title: "Open a service through the firewall with ufw"
 description: "Allow the http service and enable ufw so it filters at boot, without ever locking out SSH — the Debian firewall counterpart to firewalld, proven by ufw status."
-section: linux
+section: lfcs
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/lfcs/lfcs-mount-cifs/lab.yaml
+++ b/labs/linux/lfcs/lfcs-mount-cifs/lab.yaml
@@ -1,7 +1,7 @@
 id: lfcs-mount-cifs
 title: "Mount an SMB/CIFS share persistently and safely"
 description: "A second host serves an SMB share. Mount it on the client, make it persistent in /etc/fstab with _netdev, and keep the password out of the world-readable fstab by using a 0600 credentials file."
-section: linux
+section: lfcs
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/lfcs/lfcs-netplan-static/lab.yaml
+++ b/labs/linux/lfcs/lfcs-netplan-static/lab.yaml
@@ -1,7 +1,7 @@
 id: lfcs-netplan-static
 title: "Configure a static IP and route with netplan"
 description: "Declare a static IPv4 address and a static route in a netplan file and apply it on a dedicated interface — the Debian/Ubuntu network configuration, proven by the live address and route."
-section: linux
+section: lfcs
 lab_type: lab
 level: l4
 track:

--- a/labs/linux/lfcs/lfcs-package-apt/lab.yaml
+++ b/labs/linux/lfcs/lfcs-package-apt/lab.yaml
@@ -1,7 +1,7 @@
 id: lfcs-package-apt
 title: "Manage Debian packages with apt and dpkg"
 description: "Install a package with apt, pin it with a hold so updates skip it, and identify which package owns a file — the Debian package-management skills for LFCS."
-section: linux
+section: lfcs
 lab_type: lab
 level: l2
 track:

--- a/labs/linux/lfcs/lfcs-storage-quotas/lab.yaml
+++ b/labs/linux/lfcs/lfcs-storage-quotas/lab.yaml
@@ -1,7 +1,7 @@
 id: lfcs-storage-quotas
 title: "Enable XFS user quotas and enforce a limit"
 description: "Format a dedicated disk as XFS, mount it with user quotas enabled persistently, and enforce a block quota on a user — proven by the live quota state and the enforced limit."
-section: linux
+section: lfcs
 lab_type: lab
 level: l2
 track:


### PR DESCRIPTION
Deux correctifs indépendants, tous deux validés sur machine réelle.

## 1. Le catalogue n'était pas découpé

Les 84 `lab.yaml` déclaraient tous `section: linux`, c'est-à-dire la **catégorie du dépôt** et non leur bloc pédagogique. Deux conséquences visibles :

- `dsoxlab list-labs` rendait **un bloc unique de 84 labs**, là où le dépôt Ansible, dont chaque `lab.yaml` porte sa vraie section, s'affiche découpé par module ;
- `dsoxlab use l2` était accepté puis répondait « Aucun lab trouvé » : le filtre porte sur `lab.section`, qui valait `linux`, alors que `l1`…`l4` ne vivaient que dans le `meta.yml`, où ils ne servent qu'à ordonner.

Chaque lab reçoit désormais la section du `meta.yml`, **dérivée de son chemin relatif** sous `labs/` : rien n'est saisi à la main, le `meta.yml` reste la source unique.

| Section | Labs |
|---|---|
| `l1` | 20 |
| `l2` | 18 |
| `l3` | 14 |
| `l4` | 15 |
| `lfcs` | 6 |
| `drills` | 9 |
| `capstones` | 2 |

Le versant CLI (refuser une section inconnue au lieu de rendre un catalogue vide) est traité dans stephrobert/dsoxlab#38.

## 2. Trois tâches de drill notaient l'inverse de ce qu'elles enseignaient

**`drill-users-groups` tâche 4** — l'énoncé exige la délégation d'un seul script « et rien de plus », mais seul le versant *permis* était vérifié. Un `%ops ALL=(ALL) NOPASSWD: ALL` marquait **20/20** en accordant le root complet, malgré `validation.security: true`.

Vérifié de bout en bout sur `alma-rhcsa-1.lab` :

| Réponse | Score |
|---|---|
| `NOPASSWD: /usr/local/bin/ops-report.sh` | **100/100** |
| `NOPASSWD: ALL` | **80/100**, tâche 4 refusée |

Avant le correctif, les deux donnaient 100/100.

**`drill-firewall` tâche 5 « Telnet, jamais »** — côté RHEL, on vérifiait qu'une règle riche *vise* le port 23, jamais qu'elle le *rejette*. Une règle `accept` marquait 20/20 en ouvrant précisément ce que la tâche demande de fermer. `reject` et `drop` sont acceptés, `accept` refusé.

**`drill-users-groups` tâche 5** — le test était plus strict que son énoncé : celui-ci demande un shell qui « interdit la connexion », le test n'acceptait que `nologin` et recalait `/bin/false`, qui remplit pourtant le contrat.

Les assertions négatives vivent **dans** le test de leur tâche, sans en créer de nouveau : le score se calcule par test et les cinq tâches valent 20 points chacune ; un test de plus les ramènerait à 16,7.

Les solutions officielles chiffrées passent toujours (vérifié après déchiffrement).

## Tests

- parcours apprenant complet joué sur VM : `show` → `challenge` → `run` → résolution → `check` **100/100**, puis machine nettoyée
- `dsoxlab validate-structure` vert sur les 84 labs
- 689 tests de contenu verts
- catalogue README à jour
- hooks pre-commit verts, dont le contrôle de chiffrement des solutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
