### PR TITLE
fix(labs): annoncer dans l'énoncé ce que la validation exige vraiment

### DIFF
--- a/labs/linux/l1/l1-redirections-pipes/challenge/README.fr.md
+++ b/labs/linux/l1/l1-redirections-pipes/challenge/README.fr.md
@@ -7,11 +7,17 @@ les bons opérateurs de redirection.
 
 ## Objectif (fichiers à produire)
 
-1. `total.txt` — le **nombre de lignes** de `journal.log`.
-2. `erreurs.txt` — uniquement les lignes contenant **`ERROR`**.
-3. `stderr.txt` — le **message d'erreur** d'une commande qui échoue (lis un
-   fichier absent).
-4. `tout.txt` — la sortie standard **et** l'erreur d'une commande, **fusionnées**.
+1. `total.txt` : le **nombre de lignes** de `journal.log`.
+2. `erreurs.txt` : uniquement les lignes contenant **`ERROR`**.
+3. `stderr.txt` : le **message d'erreur** d'une commande qui échoue. Fais lire
+   le fichier absent **`inexistant.txt`**.
+4. `tout.txt` : la sortie standard **et** l'erreur d'une même commande,
+   **fusionnées**. Liste `journal.log`, qui existe, et `inexistant.txt`, qui
+   n'existe pas : `tout.txt` doit alors contenir les deux noms.
+
+Le nom `inexistant.txt` n'est pas un détail : la validation le cherche dans le
+message d'erreur, car le message du système, lui, change avec la langue du
+poste. Les commandes, elles, restent à ton choix.
 
 ## Contraintes
 

--- a/labs/linux/l1/l1-redirections-pipes/challenge/README.md
+++ b/labs/linux/l1/l1-redirections-pipes/challenge/README.md
@@ -9,9 +9,15 @@ redirection operators.
 
 1. `total.txt` — the **line count** of `journal.log`.
 2. `erreurs.txt` — only the lines containing **`ERROR`**.
-3. `stderr.txt` — the **error message** of a failing command (read a missing
-   file).
-4. `tout.txt` — the standard output **and** the error of a command, **merged**.
+3. `stderr.txt` — the **error message** of a failing command. Make it read the
+   missing file **`inexistant.txt`**.
+4. `tout.txt` — the standard output **and** the error of a single command,
+   **merged**. List `journal.log`, which exists, and `inexistant.txt`, which
+   does not: `tout.txt` must then contain both names.
+
+The name `inexistant.txt` matters: validation looks for it inside the error
+message, because the system's own message changes with the machine's language.
+The commands themselves remain your choice.
 
 ## Constraints
 


### PR DESCRIPTION
Closes #35

## Le défaut

Sur `l1-redirections-pipes`, deux exigences des tests n'étaient écrites nulle part. Un apprenant pouvait respecter l'énoncé à la lettre et voir son travail refusé.

**1. `tout.txt`, le cas rapporté.** Le test cherche `journal.log` dans le contenu, alors que l'énoncé demandait « la sortie standard **et** l'erreur d'une commande, fusionnées », sans dire laquelle. Fusionner les deux flux de n'importe quelle autre commande respectait l'énoncé et tombait en rouge.

**2. `stderr.txt` et `tout.txt`, non signalé, trouvé en jouant le lab.** Les deux tests cherchent la sous-chaîne `inexistant`. Ils imposent donc le **nom** du fichier absent, quand l'énoncé disait seulement « lis un fichier absent ». Un `cat absent.txt 2> stderr.txt` produit exactement ce qui était demandé, et échoue lui aussi.

## Le choix : corriger l'énoncé, pas les tests

Chercher le nom du fichier plutôt que le message du système est délibéré et juste. `No such file or directory` devient `Aucun fichier ou dossier de ce type` sur un poste en français : tester le message rendrait le lab dépendant de la locale. Ce choix imposait seulement d'annoncer le nom dans l'énoncé, et de dire pourquoi. Les commandes restent au libre choix de l'apprenant, ce qui préserve la promesse affichée du lab : « la validation lit le contenu réel des fichiers, pas la commande tapée ».

## Preuve

Le lab a été joué trois fois, dans un workdir propre, avec les tests réels :

| Scénario | Attendu | Obtenu |
|---|---|---|
| Le nouvel énoncé, suivi tel qu'il est écrit | vert | **5 passed** |
| Ancien énoncé, lecture fidèle nº1 (`tout.txt` produit par une autre commande) | rouge | **1 failed** sur `test_merged_stdout_stderr` |
| Ancien énoncé, lecture fidèle nº2 (fichier absent nommé `absent.txt`) | rouge | **2 failed** sur `test_stderr_captured` et `test_merged_stdout_stderr` |

Les deux scénarios rouges sont là pour prouver que le défaut existait : sans eux, la correction ne serait qu'une reformulation.

`dsoxlab validate-structure` reste vert sur les 84 labs.

## Hors sujet assumé

Les puces françaises de la liste passent de l'em-dash au deux-points, la règle d'écriture du projet proscrivant l'em-dash en français. L'anglais le conserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
