### PR TITLE
fix(tests): un replay de solution en échec doit dire pourquoi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,18 @@ repos:
         pass_filenames: false
         always_run: true
 
+      # Quand le replay d'une solution échoue, le message doit dire POURQUOI.
+      # Il ne rendait que « rc=2, 1 failure sur tel hôte » : ni la tâche
+      # fautive, ni sa raison, alors que reproduire coûte une passe entière sur
+      # l'infrastructure. La sortie du playbook était pourtant disponible, et
+      # simplement jetée. Ce test tient le message et son garde-fou d'appel.
+      - id: diagnostic-replay
+        name: un replay de solution en échec dit pourquoi
+        entry: uv run --no-project --with pytest --with pyyaml pytest tests/test_diagnostic_replay.py -q
+        language: system
+        pass_filenames: false
+        always_run: true
+
       # Les renvois internes des README et scénarios cassent en silence : rien
       # ne les exécute, seul l'apprenant tombe sur un lien mort. Le dépôt
       # Ansible jumeau en comptait 150 le jour où le test y a été écrit.

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import yaml
@@ -315,6 +315,31 @@ def _replay_shell_solution(lab_root: Path, rel_path: Path) -> None:
         )
 
 
+def message_echec_solution(lab_id: str, result: Any) -> str:
+    """Message d'échec du replay de la solution, sortie du playbook comprise.
+
+    Sans cette sortie, un échec se résume à « 1 failure sur tel hôte » : ni la
+    tâche fautive, ni sa raison. Or reproduire coûte une passe entière sur
+    l'infrastructure, ce qui a fait traîner l'incident du capstone RHCSA.
+
+    On a longtemps cru la sortie perdue, `run_playbook` créant un répertoire
+    temporaire qu'il nettoie ensuite. C'est inexact : `dsoxlab` lit le stdout
+    AVANT de supprimer ce répertoire. Vérifié en jouant un playbook en échec
+    dans les conditions exactes d'ici (`quiet=True`, `private_data_dir=None`) :
+    la tâche fautive, le `fatal:` et le `PLAY RECAP` y sont tous.
+
+    La fin plutôt que le début : Ansible s'arrête à la tâche fautive, donc
+    l'erreur est toujours dans les derniers caractères.
+    """
+    sortie = (result.stdout or "").strip()
+    detail = f"\n\nSortie du playbook (fin) :\n{sortie[-4000:]}" if sortie else ""
+    return (
+        f"solution.yaml a échoué pour {lab_id} "
+        f"(rc={result.rc}, status={result.status}). "
+        f"Stats : {result.stats}{detail}"
+    )
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _apply_lab_state(request) -> None:
     """Applique la solution officielle du formateur avant les tests.
@@ -411,8 +436,4 @@ def _apply_lab_state(request) -> None:
         vault_password_file=vault_password_file,
     )
     if not result.ok:
-        raise RuntimeError(
-            f"solution.yaml a échoué pour {lab_root.name} "
-            f"(rc={result.rc}, status={result.status}). "
-            f"Stats : {result.stats}"
-        )
+        raise RuntimeError(message_echec_solution(lab_root.name, result))

--- a/tests/test_diagnostic_replay.py
+++ b/tests/test_diagnostic_replay.py
@@ -1,0 +1,146 @@
+"""Un replay de solution en échec doit dire POURQUOI il a échoué.
+
+Incident à l'origine de ce module. Le replay de `rhcsa-mock-exam` échouait par
+intermittence, et le message se résumait à :
+
+    solution.yaml a échoué pour rhcsa-mock-exam (rc=2, status=failed).
+    Stats : {'ok': {...}, 'failures': {'alma-rhcsa-1.lab': 1}}
+
+Ni la tâche fautive, ni sa raison. Reproduire coûte une passe entière sur
+l'infrastructure, et l'issue est restée ouverte des semaines faute de matière.
+
+On a longtemps cru la sortie perdue, `run_playbook` créant un répertoire
+temporaire qu'il nettoie ensuite. C'est inexact : `dsoxlab` lit le stdout avant
+de supprimer ce répertoire. Vérifié en jouant un vrai playbook en échec dans
+les conditions exactes du conftest (`quiet=True`, `private_data_dir=None`) :
+1522 caractères, avec la tâche fautive, le `fatal:` et le `PLAY RECAP`.
+
+L'information était donc là, et c'est le conftest qui la jetait.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _charger_conftest() -> Any:
+    """Charge le conftest racine comme module, pour en tester une fonction.
+
+    Passer par importlib plutôt que par un `import conftest` : ce dernier
+    dépend du mode d'import de pytest et du répertoire courant, deux choses qui
+    varient selon qu'on lance la suite depuis la racine ou depuis `tests/`.
+    """
+    chemin = REPO / "conftest.py"
+    spec = importlib.util.spec_from_file_location("conftest_racine", chemin)
+    assert spec and spec.loader, f"conftest illisible : {chemin}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["conftest_racine"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@dataclass
+class ResultatFactice:
+    """Ce que `dsoxlab.infra.ansible.run_playbook` rend, réduit à l'utile."""
+
+    rc: int
+    status: str
+    stats: dict[str, dict[str, int]]
+    stdout: str
+
+
+#: Une sortie d'échec réaliste, calquée sur ce qu'ansible-runner produit
+#: réellement (mesuré, cf. docstring du module).
+SORTIE = (
+    "TASK [Creer le volume logique] *************************************\n"
+    'fatal: [alma-rhcsa-1.lab]: FAILED! => {"msg": "Volume group vgapp not found"}\n'
+    "\n"
+    "PLAY RECAP *********************************************************\n"
+    "alma-rhcsa-1.lab  : ok=2  changed=1  unreachable=0  failed=1\n"
+)
+
+
+@pytest.fixture(scope="module")
+def message() -> Any:
+    return _charger_conftest().message_echec_solution
+
+
+def test_la_tache_fautive_et_sa_raison_apparaissent(message: Any) -> None:
+    """Le cœur du correctif : on doit pouvoir diagnostiquer sans rejouer."""
+    texte = message(
+        "rhcsa-mock-exam",
+        ResultatFactice(
+            rc=2,
+            status="failed",
+            stats={"failures": {"alma-rhcsa-1.lab": 1}},
+            stdout=SORTIE,
+        ),
+    )
+    assert "Creer le volume logique" in texte, "la tâche fautive doit être nommée"
+    assert "Volume group vgapp not found" in texte, "la raison doit être donnée"
+
+
+def test_le_message_garde_ce_qu_il_disait_deja(message: Any) -> None:
+    """Le correctif ajoute, il ne remplace pas : rc, status et stats restent."""
+    texte = message(
+        "rhcsa-mock-exam",
+        ResultatFactice(rc=2, status="failed", stats={"ok": {"h": 4}}, stdout=SORTIE),
+    )
+    assert "rhcsa-mock-exam" in texte
+    assert "rc=2" in texte
+    assert "status=failed" in texte
+    assert "{'ok': {'h': 4}}" in texte
+
+
+@pytest.mark.parametrize("vide", ["", "   ", "\n\n  \n"])
+def test_sans_sortie_aucune_section_vide(message: Any, vide: str) -> None:
+    """Un playbook muet ne doit pas produire un en-tête suivi de rien.
+
+    Une section « Sortie du playbook » vide laisse croire que le playbook n'a
+    rien dit, alors que le cas réel est qu'on n'a pas su la lire.
+    """
+    texte = message(
+        "un-lab", ResultatFactice(rc=1, status="failed", stats={}, stdout=vide)
+    )
+    assert "Sortie du playbook" not in texte
+    assert "rc=1" in texte
+
+
+def test_une_sortie_enorme_est_tronquee(message: Any) -> None:
+    """Un playbook verbeux ne doit pas noyer la console de l'utilisateur.
+
+    On garde la FIN : Ansible s'arrête à la tâche fautive, donc l'erreur est
+    toujours dans les derniers caractères. Tronquer par le début la perdrait.
+    """
+    bruit = "ligne de bruit sans intérêt\n" * 2000
+    texte = message(
+        "un-lab",
+        ResultatFactice(
+            rc=2, status="failed", stats={}, stdout=bruit + SORTIE
+        ),
+    )
+    assert len(texte) < 6000, "le message doit rester lisible dans un terminal"
+    assert "Volume group vgapp not found" in texte, (
+        "la fin doit survivre à la troncature, c'est là qu'est l'erreur"
+    )
+
+
+def test_la_fixture_de_replay_utilise_bien_cette_fonction() -> None:
+    """Garde-fou : la fonction ne doit pas devenir du code mort.
+
+    Les tests ci-dessus passeraient encore si quelqu'un remettait un message
+    en dur dans la fixture. On vérifie donc que c'est bien elle qui est appelée.
+    """
+    source = (REPO / "conftest.py").read_text(encoding="utf-8")
+    assert "raise RuntimeError(message_echec_solution(" in source, (
+        "la fixture _apply_lab_state doit lever avec message_echec_solution(), "
+        "sinon cette fonction est testée mais jamais utilisée"
+    )


### PR DESCRIPTION
Refs #18

## Le problème

Quand le replay d'une solution échoue, le message se résume à :

```
solution.yaml a échoué pour rhcsa-mock-exam (rc=2, status=failed).
Stats : {'ok': {...}, 'failures': {'alma-rhcsa-1.lab': 1}}
```

Ni la tâche fautive, ni sa raison. Reproduire coûte une passe entière sur l'infrastructure, et l'issue #18 est restée ouverte faute de matière à analyser.

## L'hypothèse de l'issue est fausse, et c'est ce qui débloque

L'issue #18 suppose que la sortie est perdue parce que `run_playbook(private_data_dir=None)` crée un répertoire temporaire qu'il nettoie ensuite.

**Vérifié en jouant un vrai playbook en échec**, dans les conditions exactes de la fixture (`quiet=True`, `private_data_dir=None`, les deux par défaut), sur localhost donc sans aucune VM :

```
  ok      = False
  rc      = 2
  status  = failed
  stdout  = 1522 caractères
```

Ces 1522 caractères contiennent la tâche fautive, le `fatal:` complet avec son message, et le `PLAY RECAP`. `dsoxlab` lit en effet le stdout **avant** de supprimer le répertoire (`infra/ansible.py`, `_read_stdout()` est appelé dans le `return`, le `cleanup()` n'intervient que dans le `finally` qui suit).

L'information était donc disponible depuis le début, et c'est **ce `conftest.py` qui la jetait**.

## Ce que fait cette PR

Le formatage du message est extrait dans `message_echec_solution()` et joint la fin de la sortie. Extraire plutôt que corriger sur place n'est pas cosmétique : un bloc noyé dans une fixture de cent lignes qui exige une VM ne se teste pas.

Le message devient :

```
solution.yaml a échoué pour rhcsa-mock-exam (rc=2, status=failed). Stats : {...}

Sortie du playbook (fin) :
TASK [Creer le volume logique] ***********************************
fatal: [alma-rhcsa-1.lab]: FAILED! => {"msg": "Volume group vgapp not found"}

PLAY RECAP *******************************************************
alma-rhcsa-1.lab  : ok=2  changed=1  unreachable=0  failed=1
```

## Tests, et leur vérification par mutation

`tests/test_diagnostic_replay.py` couvre cinq comportements : la tâche fautive et sa raison, la conservation de `rc`/`status`/`stats`, l'absence de section vide quand le playbook n'a rien dit, la troncature par la **fin** (Ansible s'arrête à la tâche fautive, donc l'erreur y est toujours), et le fait que la fixture appelle bien cette fonction, sans quoi elle serait du code mort testé pour rien.

Un test qui passe ne prouve rien tant qu'on ne l'a pas vu échouer. Les trois mutations suivantes ont été jouées, chacune doit rendre la suite rouge :

| Mutation | Résultat |
|---|---|
| Retirer la sortie du message | 2 failed |
| Tronquer par le début au lieu de la fin | 1 failed |
| Débrancher la fonction de la fixture | 1 failed |

Le hook pre-commit qui lance ce test est câblé, comme l'exige `tests/test_outillage_coherent.py` : un vérificateur présent mais débranché ne protège plus rien, en silence.

Suite complète après rebase : **865 passed, 2 skipped**. `ruff` vert.

## Ce que cette PR ne fait pas

**Elle ne résout pas #18.** La cause de l'échec intermittent reste inconnue, et sa reproduction demande l'infrastructure. Elle rend la prochaine occurrence lisible du premier coup, ce qui est le préalable à toute résolution. L'issue reste donc ouverte, d'où un `Refs` et non un `Closes`.

## Note de sécurité

Ce chemin ne s'exécute **jamais** chez un apprenant : `dsoxlab check` pose `LAB_NO_REPLAY=1` (`lab_service.py:345`), et `.vault-pass` n'est pas versionné (`.gitignore:220`), donc les solutions restent indéchiffrables sans le mot de passe du formateur. Joindre la sortie d'un playbook de solution n'expose donc rien de plus qu'à celui qui possède déjà la solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
