### PR TITLE
chore(ci): grouper les mises à jour dependabot, une branche par lot et non par paquet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,23 @@ updates:
     # validation du fichier côté GitHub.
     cooldown:
       default-days: 7
+    # Un lot par semaine plutôt qu'une branche par action. Cinq PR étaient
+    # ouvertes en même temps, dont trois pour les trois actions
+    # github/codeql-action/*, qui sortent toujours la même version le même jour
+    # et ne se fusionnent jamais séparément. Chacune ouvrait une branche et
+    # déclenchait une CI complète.
+    #
+    # Les majeures restent seules : ce sont elles qui cassent, elles méritent
+    # d'être lues, et les grouper ferait qu'une action incompatible bloquerait
+    # toutes les autres du même lot.
+    #
+    # Les alertes de sécurité restent hors groupe, ce qui est le défaut
+    # (`applies-to: version-updates`) : elles sont urgentes et méritent une PR
+    # ciblée plutôt que d'attendre le lot hebdomadaire.
+    groups:
+      actions-mineures-et-correctives:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Pas d'écosystème "uv" ici : ce dépôt de contenu n'a aucune dépendance
   # Python à builder (pyproject.toml : package = false, dependencies = []).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,22 @@ repos:
         types_or: [python, pyi]
         require_serial: true
 
+      # Une dependabot.yml invalide est refusée en bloc par GitHub, qui cesse
+      # alors d'ouvrir des PR : cela ressemble exactement à « aucune mise à
+      # jour disponible ». Ce dépôt en a fait les frais avec des paliers
+      # semver-*-days que l'écosystème github-actions ne supporte pas.
+      #
+      # Portée mesurée en soumettant au hook chacune de ces fautes : il rejette
+      # une clé mal orthographiée, une valeur d'update-types inventée et un
+      # écosystème inexistant. Il n'attrape PAS les restrictions par
+      # écosystème, y compris le cas semver-*-days ci-dessus, légal ailleurs.
+      # Il réduit donc l'écart, il ne le ferme pas.
+      - id: dependabot-schema
+        name: dependabot.yml est conforme au schéma officiel
+        entry: uvx check-jsonschema --builtin-schema vendor.dependabot
+        language: system
+        files: '^\.github/dependabot\.yml$'
+
       - id: trufflehog
         name: trufflehog (secret scan)
         # --no-update: never auto-fetch a new binary at hook time (supply-chain hardening).


### PR DESCRIPTION
## Le problème

**Cinq PR dependabot étaient ouvertes en même temps.** Trois d'entre elles portaient les actions `github/codeql-action/*` (`init`, `analyze`, `upload-sarif`), qui sortent toujours la même version le même jour et ne se fusionnent jamais séparément. Chacune ouvre une branche et déclenche une CI complète, pour un lot que personne ne relit action par action.

## Ce que change cette PR

Un groupe rassemble tout ce qui n'est ni majeur ni une alerte de sécurité.

| Avant | Après |
|---|---|
| `codeql-action/init`, `codeql-action/analyze`, `codeql-action/upload-sarif`, `plumber` | **1 PR** `actions-mineures-et-correctives` |
| `setup-uv` 8.3.2 → 9.0.0 | **1 PR**, seule, comme il se doit |

Soit **2 PR au lieu de 5**.

Ce dépôt n'a qu'un écosystème, `github-actions` : il n'a aucune dépendance Python à builder, et sa seule dev-dep est `dsoxlab`, déclaré en chemin local que Dependabot ne sait pas atteindre. Le commentaire qui l'explique est conservé tel quel.

## Deux choix explicités

**Les majeures restent individuelles.** Ce sont elles qui cassent, elles méritent d'être lues, et les grouper ferait qu'une action incompatible bloquerait toutes les autres du même lot.

**Les alertes de sécurité restent hors groupe**, ce qui est le défaut (`applies-to: version-updates`). Elles sont urgentes et méritent une PR ciblée plutôt que d'attendre le lot hebdomadaire.

## Le garde-fou, et ses limites mesurées

Une `dependabot.yml` invalide est refusée **en bloc** par GitHub, qui cesse alors d'ouvrir des PR : cela ressemble exactement à « aucune mise à jour disponible ». Ce dépôt en a fait les frais, avec des paliers `semver-*-days` que l'écosystème `github-actions` ne supporte pas (le commentaire du fichier en garde la trace).

Un hook valide donc le fichier contre le schéma officiel quand il change. Sa portée a été mesurée en lui soumettant chacune de ces fautes :

| Faute | Verdict |
|---|---|
| Clé mal orthographiée (`groupes:` pour `groups:`) | rejetée |
| Valeur d'`update-types` inventée | rejetée |
| Écosystème inexistant | rejetée |
| Paliers `semver-*-days` sous `github-actions` | **acceptée**, alors que GitHub les refuse |

Autrement dit, le hook ne protège pas du cas précis déjà vécu ici : le schéma le laisse passer parce qu'il est légal pour d'autres écosystèmes. Il réduit l'écart sans le fermer, et son commentaire le dit, pour ne pas rassurer à tort.

## Effet sur les 5 PR ouvertes

Dependabot consolidera au prochain passage hebdomadaire : il ferme les PR individuelles devenues redondantes et ouvre les lots. Rien à faire à la main, sinon fermer les PR existantes pour que cela aille plus vite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
