### PR TITLE
fix(labs): ce que la solution crée, le cleanup doit le rendre

### DIFF
--- a/labs/linux/capstones/rhcsa-mock-exam/cleanup.yaml
+++ b/labs/linux/capstones/rhcsa-mock-exam/cleanup.yaml
@@ -37,8 +37,15 @@
         # Les taches 6 et 7 creent appuser, devuser et le groupe developers.
         # Les laisser en place occupe des UID/GID que d autres labs posent a
         # leur tour, et fait echouer leur useradd a la place de celui-ci.
-        userdel -r appuser 2>/dev/null
-        userdel -r devuser 2>/dev/null
+        # `userdel` REFUSE tant qu un processus appartient au compte, et le
+        # service myapp.service vient a peine d etre arrete : sans -f, la
+        # suppression echouait en silence (2>/dev/null), appuser gardait
+        # l UID 1500, et l2-user-lifecycle echouait ensuite sur
+        # « useradd: UID 1500 is not unique ». On tue d abord, on force ensuite.
+        pkill -KILL -u appuser 2>/dev/null
+        pkill -KILL -u devuser 2>/dev/null
+        userdel -rf appuser 2>/dev/null
+        userdel -rf devuser 2>/dev/null
         groupdel developers 2>/dev/null
         vgchange -an vgapp 2>/dev/null
         vgremove -f vgapp 2>/dev/null

--- a/scripts/verify-solutions.py
+++ b/scripts/verify-solutions.py
@@ -45,6 +45,9 @@ VAULT_PASS = REPO / ".vault-pass"
 
 VM_RUNTIMES = {"vm", "kvm", "incus"}
 
+#: Sortie complete du dernier pytest joue, conservee pour les echecs.
+DERNIERE_SORTIE = ""
+
 
 # ── découverte ────────────────────────────────────────────────────────────────
 
@@ -210,6 +213,11 @@ def jouer(lab: Lab, *, rejeu: bool) -> tuple[bool, str]:
     )
     lignes = [ligne for ligne in proc.stdout.strip().splitlines() if ligne.strip()]
     resume = lignes[-1] if lignes else "aucune sortie"
+    # La sortie complete est conservee pour les rouges : un resume du type
+    # « 4 errors » ne dit RIEN de la cause, et reproduire un echec de sequence
+    # coute une passe entiere. On garde de quoi diagnostiquer sans rejouer.
+    global DERNIERE_SORTIE
+    DERNIERE_SORTIE = (proc.stdout + proc.stderr)[-6000:]
     return proc.returncode == 0, resume
 
 
@@ -319,6 +327,8 @@ def main() -> int:
                 )
                 ok = False
 
+        if not ok:
+            entree["sortie"] = DERNIERE_SORTIE
         verdicts[lab.id] = entree
         if ok:
             verts += 1

--- a/tests/test_marqueurs_setup_cleanup.py
+++ b/tests/test_marqueurs_setup_cleanup.py
@@ -111,6 +111,85 @@ COMPTES = [
 ]
 
 
+# ── comptes créés par la SOLUTION ─────────────────────────────────────────────
+#
+# La solution est chiffrée, donc illisible par un test. Mais les tests du lab,
+# eux, nomment forcément les comptes qu'ils attendent : c'est leur objet.
+#
+# Le cas qui a coûté le plus cher : `rhcsa-mock-exam` fait créer `appuser` avec
+# l'UID 1500 par sa solution, et son cleanup échouait à le supprimer. Cinquante
+# labs plus loin, `l2-user-lifecycle` créait `alice` avec ce même UID et
+# tombait sur « useradd: UID 1500 is not unique ». Le lab accusé n'était pas le
+# lab fautif, et il passait parfaitement joué seul.
+
+def _est_supprime(cleanup: str, nom: str) -> bool:
+    """Le cleanup SUPPRIME-t-il réellement ce compte ou ce groupe ?
+
+    Chercher le nom n'importe où ne suffit pas : un commentaire qui le cite,
+    ou un `pkill -u <nom>` qui ne fait que tuer ses processus, satisfaisaient
+    la vérification sans rien supprimer. Ce test a d'ailleurs commencé sa vie
+    ainsi, et il passait sur un cleanup dont on venait de retirer le
+    `userdel`.
+
+    On exige donc une vraie commande de suppression :
+
+    - `userdel …  <nom>` / `groupdel … <nom>` (shell) ;
+    - ou un module Ansible `name: <nom>` suivi de `state: absent`.
+    """
+    echappe = re.escape(nom)
+    if re.search(rf"^\s*(?:user|group)del[^\n#]*\b{echappe}\b", cleanup, re.MULTILINE):
+        return True
+
+    # Forme Ansible. On découpe en tâches, et on accepte celle qui porte à la
+    # fois `state: absent` et le nom. Cela couvre le `name: alice` direct comme
+    # la boucle `name: "{{ item }}"` + `loop:` dont les entrées listent les
+    # comptes : c'est la forme qu'emploie `drill-users-groups`, et un motif
+    # calé sur `name: <nom>` la déclarait fautive à tort.
+    for tache in re.split(r"\n\s*- name:", cleanup):
+        if "state: absent" in tache and re.search(rf"\b{echappe}\b", tache):
+            return True
+    return False
+
+
+#: `<hôte>.user("X")` dans un test : le compte que le lab attend. La fixture
+#: ne s'appelle pas toujours `host` : le capstone RHCSA écrit `srv1.user(...)`,
+#: et un motif calé sur `host` laissait justement passer `appuser`, le compte
+#: qui a causé tout ce diagnostic.
+_COMPTE_TESTE = re.compile(r'\b\w+\.user\(\s*"(?P<nom>[a-z][\w-]*)"\s*\)')
+
+COMPTES_TESTES = [
+    (lab, nom)
+    for lab in _labs_avec_setup()
+    for test in [lab / "challenge" / "tests" / "test_functional.py"]
+    if test.is_file()
+    for nom in sorted(set(_COMPTE_TESTE.findall(test.read_text(encoding="utf-8"))))
+    if nom not in SYSTEME
+]
+
+
+@pytest.mark.parametrize(
+    ("lab", "nom"),
+    COMPTES_TESTES,
+    ids=[f"{lab.name}:{nom}" for lab, nom in COMPTES_TESTES],
+)
+def test_le_cleanup_supprime_les_comptes_attendus(lab: Path, nom: str) -> None:
+    """Ce que la solution crée, le cleanup doit le rendre.
+
+    Un compte survivant garde son UID, et le lab qui voudra le même UID
+    échouera à sa place, souvent très loin dans la séquence.
+    """
+    cleanup = lab / "cleanup.yaml"
+    assert cleanup.is_file(), f"{lab.name} a un setup.yaml mais pas de cleanup.yaml"
+
+    assert _est_supprime(cleanup.read_text(encoding="utf-8"), nom), (
+        f"{lab.name} : les tests attendent le compte « {nom} », que le cleanup "
+        f"ne SUPPRIME pas.\n"
+        f"S'il est créé par la solution, il survivra au nettoyage et gardera "
+        f"son UID pour tous les labs suivants.\n"
+        f"Ajouter par exemple :  userdel -rf {nom}"
+    )
+
+
 @pytest.mark.parametrize(
     ("lab", "genre", "nom"),
     COMPTES,


### PR DESCRIPTION
## Le défaut, et pourquoi il était si difficile à voir

Le capstone RHCSA fait créer `appuser` avec l'**UID 1500** par sa solution, et son `cleanup.yaml` échouait à le supprimer. `userdel` refuse tant qu'un processus appartient au compte, et `myapp.service` venait d'être arrêté : le `2>/dev/null` avalait l'échec, `appuser` survivait, et gardait son UID.

**Cinquante labs plus loin**, `l2-user-lifecycle` créait `alice` avec ce même UID et tombait sur `useradd: UID 1500 is not unique`.

Le lab accusé n'était donc pas le lab fautif, et il passait parfaitement joué seul. C'est le pire cas de figure pour un diagnostic : le symptôme est loin de la cause, et il disparaît dès qu'on l'isole.

Le correctif tue d'abord, force ensuite : `pkill -KILL -u` puis `userdel -rf`.

## Le test qui empêche la récidive, sur les 84 labs

La solution est chiffrée, donc illisible par un test. Mais **les tests d'un lab nomment forcément les comptes qu'ils attendent**, c'est leur objet. On en déduit les comptes, et on exige du `cleanup.yaml` une vraie commande de suppression.

Le point important est ce que le test refuse de considérer comme une suppression : chercher le nom quelque part ne suffit pas. Un commentaire qui le cite, ou un `pkill -u <nom>` qui ne fait que tuer ses processus, satisfaisaient la vérification sans rien supprimer. **Ce test a commencé sa vie ainsi**, et il passait sur un cleanup dont on venait de retirer le `userdel`. Il exige donc désormais soit `userdel`/`groupdel`, soit un module Ansible avec `state: absent`, la forme en boucle `loop:` comprise (c'est celle de `drill-users-groups`, qu'un motif calé sur `name: <nom>` déclarait fautive à tort).

## Preuve

Un test qui n'a jamais échoué ne prouve rien. En remplaçant `userdel -rf appuser` par un no-op :

```
FAILED tests/test_marqueurs_setup_cleanup.py::test_le_cleanup_supprime_les_comptes_attendus[rhcsa-mock-exam:appuser]
1 failed, 44 passed, 1 skipped
```

Il tombe précisément sur le cas visé, et sur lui seul.

| Contrôle | Résultat |
|---|---|
| Suite complète | **870 passed, 2 skipped** |
| `ruff` | vert |
| `dsoxlab validate-structure` | 84 labs valides |

## Diagnostic des campagnes

`scripts/verify-solutions.py` conserve désormais la sortie complète du pytest en échec. Un résumé du type « 4 errors » ne dit rien de la cause, et reproduire un échec de séquence coûte une passe entière sur l'infrastructure. C'est le pendant, côté campagne, de ce que la PR #42 a fait côté fixture.

## Ce qui n'est délibérément pas dans cette PR

`solution/verified-with.json` n'est **pas** inclus. La campagne du 27/07 à 14:20 y attestait 82 verts, un rouge (`l2-filesystem-create-xfs`, « 4 errors in 1.36s ») et un ignoré (`l3-fs-readonly-recover`, hôte `dark`), contre 83 verts dans la version actuelle : livrer ce fichier publierait une attestation en recul, et sans explication.

Ces deux échecs restent à instruire. Ils sont muets aujourd'hui (leurs entrées ne portent pas de champ `sortie`, la campagne ayant tourné avant le correctif ci-dessus), mais `4 errors` est la signature d'une **erreur de fixture**, donc du replay de solution, pas de tests qui échouent. Avec ce correctif et la PR #42, une nouvelle campagne nommera la tâche fautive et sa raison. Le fichier se régénérera à ce moment-là.

Piste déjà écartée : le `cleanup.yaml` de `l2-filesystem-create-xfs` efface bien son marqueur `.xfs-lab-ready`, ce n'est donc pas la rechute de l'incident historique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
