### PR TITLE
fix(tests): exiger que le cleanup EFFACE le marqueur, pas qu'il le mentionne

### DIFF
--- a/labs/linux/l2/l2-autofs-ondemand/cleanup.yaml
+++ b/labs/linux/l2/l2-autofs-ondemand/cleanup.yaml
@@ -21,5 +21,5 @@
         wipefs -a "$part" 2>/dev/null || true
         wipefs -a "$DISK" 2>/dev/null || true
         partprobe "$DISK" 2>/dev/null || true
-        rm -f /root/.autofs-lab-ready
+        rm -f /root/.autofs-lab-ready /root/autofs-disk.env
       changed_when: false

--- a/labs/linux/l2/l2-disk-space-troubleshoot/cleanup.yaml
+++ b/labs/linux/l2/l2-disk-space-troubleshoot/cleanup.yaml
@@ -27,3 +27,6 @@
       loop:
         - /srv/data
         - /root/.dsk-lab-ready
+        # Lu plus haut pour connaître le disque : il doit partir avec
+        # le reste, sinon le prochain setup saute la détection.
+        - /root/dsk-disk.env

--- a/labs/linux/l2/l2-partition-gpt/cleanup.yaml
+++ b/labs/linux/l2/l2-partition-gpt/cleanup.yaml
@@ -20,4 +20,5 @@
         wipefs -a "$DISK" 2>/dev/null || true
         sgdisk --zap-all "$DISK" 2>/dev/null || true
         partprobe "$DISK" 2>/dev/null || true
+        rm -f /root/part-disk.env
       changed_when: false

--- a/labs/linux/l2/l2-storage-performance/cleanup.yaml
+++ b/labs/linux/l2/l2-storage-performance/cleanup.yaml
@@ -25,5 +25,5 @@
         wipefs -a "$part" 2>/dev/null || true
         wipefs -a "$DISK" 2>/dev/null || true
         partprobe "$DISK" 2>/dev/null || true
-        rm -rf /srv/data /root/.perf-lab-ready
+        rm -rf /srv/data /root/.perf-lab-ready /root/perf-disk.env
       changed_when: false

--- a/labs/linux/l3/l3-fs-readonly-recover/cleanup.yaml
+++ b/labs/linux/l3/l3-fs-readonly-recover/cleanup.yaml
@@ -15,6 +15,6 @@
           . /root/fsro-disk.env
           part="${DISK}1"; [ -b "$part" ] || part="${DISK}p1"
           wipefs -a "$part" 2>/dev/null || true
-          rm -f /root/.fsro-ready
+          rm -f /root/.fsro-ready /root/fsro-disk.env
         chdir: /
       changed_when: false

--- a/tests/test_marqueurs_setup_cleanup.py
+++ b/tests/test_marqueurs_setup_cleanup.py
@@ -55,6 +55,32 @@ CAS = [
 ]
 
 
+def _est_efface(cleanup: str, marqueur: str) -> bool:
+    """Le cleanup EFFACE-t-il réellement ce marqueur ?
+
+    Le mentionner ne suffit pas : « . /root/xxx.env » le lit sans le rendre, et
+    un commentaire qui le cite satisfaisait la vérification. C'est exactement le
+    piège que la partie « comptes » de ce module avait déjà corrigé avec
+    `_est_supprime()`, dont la docstring note : « ce test a commencé sa vie
+    ainsi, et il passait sur un cleanup dont on venait de retirer le userdel ».
+    La leçon n'avait pas été reportée ici.
+
+    Deux formes légitimes, et seulement elles :
+
+    - shell : ``rm`` suivi du chemin, éventuellement parmi d'autres ;
+    - Ansible : une tâche qui porte à la fois le chemin et ``state: absent``.
+    """
+    echappe = re.escape(marqueur)
+    # `rm -f a b c` : le marqueur peut être n'importe lequel des chemins.
+    if re.search(rf"^\s*rm\b[^\n#]*\s{echappe}(\s|$)", cleanup, re.MULTILINE):
+        return True
+    # Une tâche Ansible se délimite au « - name: » suivant.
+    for tache in re.split(r"\n\s*- name:", cleanup):
+        if "state: absent" in tache and re.search(rf"{echappe}(\s|$|\")", tache):
+            return True
+    return False
+
+
 @pytest.mark.parametrize(
     ("lab", "marqueur"),
     CAS,
@@ -70,9 +96,11 @@ def test_le_cleanup_efface_le_marqueur(lab: Path, marqueur: str) -> None:
     assert cleanup.is_file(), f"{lab.name} a un setup.yaml mais pas de cleanup.yaml"
 
     texte = cleanup.read_text(encoding="utf-8")
-    assert marqueur in texte, (
+    assert _est_efface(texte, marqueur), (
         f"{lab.name} : le setup se garde avec « creates: {marqueur} », mais le "
-        f"cleanup ne mentionne jamais ce chemin.\n"
+        f"cleanup ne l'EFFACE jamais.\n"
+        f"Le mentionner ne suffit pas — « . {marqueur} » le lit, un commentaire "
+        f"le cite — et cette vérification a d'ailleurs commencé sa vie ainsi.\n"
         f"Le nettoyage laissera donc le marqueur en place : au prochain setup, "
         f"la tâche sera sautée et l'état de départ ne sera jamais reconstruit.\n"
         f"Ajouter par exemple :  rm -f {marqueur}"


### PR DESCRIPTION
# Summary

> Remplace #55, dont la branche était partie d'un `main` antérieur au merge de
> #46 et ne se rebasait pas proprement. Même contenu, rejoué sur le `main`
> actuel.

Le test devait garantir qu'un lab reste rejouable : ce qu'un `creates:` protège,
le `cleanup.yaml` doit le rendre. Sa vérification était `assert marqueur in
texte` — le chemin apparaît **quelque part** dans le fichier. Un commentaire qui
le cite, ou la lecture `. /root/xxx.env`, satisfaisaient la condition sans rien
supprimer.

## Le défaut, reproduit avant d'être corrigé

La mutation exacte que décrit l'issue, sur `l2-filesystem-create-xfs` :

```diff
-          rm -f /root/xfs-disk.env /root/.xfs-lab-ready
+          echo "cités mais jamais effacés : /root/xfs-disk.env /root/.xfs-lab-ready"
```

| | Résultat |
|---|---|
| avant le correctif | `45 passed, 1 skipped` — **le test ne voit rien** |
| après le correctif | `2 failed, 43 passed, 1 skipped` |

C'est le piège que la partie « comptes » du même module avait **déjà** corrigé
avec `_est_supprime()`, dont la docstring note : *« ce test a commencé sa vie
ainsi, et il passait sur un cleanup dont on venait de retirer le `userdel` »*.
La leçon n'avait pas été reportée sur les marqueurs.

## Cinq labs remontés, cinq corrigés, aucun exempté

La vérification stricte a fait remonter **cinq** labs — l'issue le prévoyait — et
tous pour la même raison : le cleanup **lit** le `.env` pour connaître le disque,
puis ne l'efface jamais.

| Lab | Ce qui manquait |
|---|---|
| `l2-autofs-ondemand` | `autofs-disk.env` absent du `rm` |
| `l2-disk-space-troubleshoot` | `dsk-disk.env` absent de la loop `state: absent` |
| `l2-partition-gpt` | **aucune suppression du tout** |
| `l2-storage-performance` | `perf-disk.env` absent du `rm -rf` |
| `l3-fs-readonly-recover` | `fsro-disk.env` absent du `rm -f` — le lab de #48 |

La suppression est placée **après** la lecture dans chaque cas : l'effacer avant
priverait le cleanup de la variable dont il a besoin. Trois formes distinctes,
traitées une par une plutôt que par une substitution générale qui aurait placé le
`rm` au mauvais endroit dans au moins l'une d'elles.

## Ce que `_est_efface()` accepte

Deux formes, et seulement elles :

- **shell** : `rm` suivi du chemin, éventuellement parmi d'autres ;
- **Ansible** : une tâche portant à la fois le chemin et `state: absent`.

## Vérification, rejouée sur le `main` actuel

- la mutation de l'issue rend le test **rouge** ;
- les cinq `cleanup.yaml` restent du YAML valide et passent
  `ansible-playbook --syntax-check` ;
- **880 tests verts** (le catalogue en comptait 871 avant le merge de #46) ;
- le travail de #46 est préservé : aucun de ses cleanups n'est remonté par la
  vérification stricte.

## Critères de l'issue

- [x] La mutation ci-dessus rend le test **rouge**.
- [x] `l3-fs-readonly-recover` est signalé par le test, puis corrigé (#48).
- [x] Tout autre lab remonté est corrigé — les quatre autres le sont, aucune exemption ajoutée.
- [x] Les formes légitimes restent acceptées : `rm -f` à plusieurs chemins, et `ansible.builtin.file` avec `state: absent`.

## Related issues

Closes #49
Refs #48 — le marqueur de `l3-fs-readonly-recover` est corrigé ici. Le point 1 de
cette issue (l'hôte qui devient injoignable en séquence) reste ouvert : il demande
une campagne de validation réelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)